### PR TITLE
Forward declare class Cursor

### DIFF
--- a/include/tntdb/oracle/statement.h
+++ b/include/tntdb/oracle/statement.h
@@ -45,6 +45,7 @@ namespace tntdb
   namespace oracle
   {
     class Connection;
+    class Cursor;
 
     class Statement : public IStatement
     {


### PR DESCRIPTION
Class Cursor is referentiated as "friend" in the Statement class. Without the forward declaration of class Cursor, tntdb won't compile (AIX 6.1, xlC_r)